### PR TITLE
Implement + and -

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,11 @@ fn main() {
     let mut source_bytes = source.bytes().enumerate().peekable();
 
     match read_number(source, &mut source_bytes) {
-        Some(code) => {
+        Some(number) => {
             println!(".global main");
             println!("main:");
             println!(" mov x8, #93"); // setup exit syscall
-            println!(" mov x0, #{}", code); // exit code is 42
+            println!(" mov x0, #{}", number);
             println!(" svc #0"); // invoke syscall
         }
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,22 +11,24 @@ fn main() {
         process::exit(1);
     }
 
+    println!(".global main");
+    println!("main:");
+
     let source = &args[1];
     let mut source_bytes = source.bytes().enumerate().peekable();
 
     match read_number(source, &mut source_bytes) {
         Some(number) => {
-            println!(".global main");
-            println!("main:");
-            println!(" mov x8, #93"); // setup exit syscall
             println!(" mov x0, #{}", number);
-            println!(" svc #0"); // invoke syscall
         }
         None => {
             eprintln!("Usage: rucco <exit_code>");
             process::exit(1);
         }
     }
+
+    println!(" mov x8, #93");
+    println!(" svc #0");
 }
 
 fn read_number<'a>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ fn main() {
     }
 
     let source = &args[1];
-    match read_number(source) {
+    let mut source_bytes = source.bytes();
+
+    match read_number(source, &mut source_bytes) {
         Some(code) => {
             println!(".global main");
             println!("main:");
@@ -24,12 +26,11 @@ fn main() {
     }
 }
 
-fn read_number(source: &str) -> Option<&str> {
-    let mut bytes = source.bytes();
+fn read_number<'a>(source: &'a str, source_bytes: &mut std::str::Bytes<'_>) -> Option<&'a str> {
     let mut len: usize = 0;
 
     loop {
-        match bytes.next() {
+        match source_bytes.next() {
             Some(byte) => {
                 if byte.is_ascii_digit() {
                     len += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 use std::env;
+use std::iter::Enumerate;
+use std::iter::Peekable;
 use std::process;
+use std::str::Bytes;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -9,7 +12,7 @@ fn main() {
     }
 
     let source = &args[1];
-    let mut source_bytes = source.bytes();
+    let mut source_bytes = source.bytes().enumerate().peekable();
 
     match read_number(source, &mut source_bytes) {
         Some(code) => {
@@ -26,12 +29,15 @@ fn main() {
     }
 }
 
-fn read_number<'a>(source: &'a str, source_bytes: &mut std::str::Bytes<'_>) -> Option<&'a str> {
+fn read_number<'a>(
+    source: &'a str,
+    source_bytes: &mut Peekable<Enumerate<Bytes<'_>>>,
+) -> Option<&'a str> {
     let mut len: usize = 0;
 
     loop {
         match source_bytes.next() {
-            Some(byte) => {
+            Some((_, byte)) => {
                 if byte.is_ascii_digit() {
                     len += 1;
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::str::Bytes;
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
-        eprintln!("Usage: rucco <exit_code>");
+        eprintln!("Usage: rucco <source>");
         process::exit(1);
     }
 
@@ -22,8 +22,36 @@ fn main() {
             println!(" mov x0, #{}", number);
         }
         None => {
-            eprintln!("Usage: rucco <exit_code>");
+            eprintln!("Usage: rucco <source>");
             process::exit(1);
+        }
+    }
+
+    loop {
+        match source_bytes.next() {
+            Some((_, b'+')) => match read_number(source, &mut source_bytes) {
+                Some(number) => {
+                    println!(" add x0, x0, #{}", number);
+                }
+                None => {
+                    eprintln!("expected number");
+                    process::exit(1);
+                }
+            },
+            Some((_, b'-')) => match read_number(source, &mut source_bytes) {
+                Some(number) => {
+                    println!(" sub x0, x0, #{}", number);
+                }
+                None => {
+                    eprintln!("expected number");
+                    process::exit(1);
+                }
+            },
+            Some((i, _)) => {
+                eprintln!("expected `+` or `-` at #{}", i);
+                process::exit(1);
+            }
+            None => break,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,25 @@ fn read_number<'a>(
     source: &'a str,
     source_bytes: &mut Peekable<Enumerate<Bytes<'_>>>,
 ) -> Option<&'a str> {
+    let start: usize;
     let mut len: usize = 0;
 
+    match source_bytes.peek() {
+        Some((i, byte)) => {
+            if byte.is_ascii_digit() {
+                start = *i;
+                len += 1;
+            } else {
+                return None;
+            }
+        }
+        None => return None,
+    }
+
     loop {
-        match source_bytes.next() {
+        source_bytes.next();
+
+        match source_bytes.peek() {
             Some((_, byte)) => {
                 if byte.is_ascii_digit() {
                     len += 1;
@@ -48,5 +63,5 @@ fn read_number<'a>(
         }
     }
 
-    source.get(0..len)
+    source.get(start..(start + len))
 }

--- a/test.sh
+++ b/test.sh
@@ -19,5 +19,7 @@ assert() {
 
 assert 0 0
 assert 42 42
+assert 3 "1+2"
+assert 233 "0+11+222"
 
 echo OK


### PR DESCRIPTION
- Share source bytes
- Make source_bytes Peekable and Enumerate
- Make read_number reusable
- Tweak variable name
- Separate prelude and postlude
- Implement + and -
